### PR TITLE
Added username and password for authentification.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
                 <artifactId>job-streamer-maven-plugin</artifactId>
                 <version>0.1.0</version>
                 <configuration>
+                    <username>admin</username>
+                    <password>password123</password>
                     <controlBusHost>localhost</controlBusHost>
                     <controlBusPort>45102</controlBusPort>
                     <name>job-streamer-examples</name>


### PR DESCRIPTION
Deploying application needs authentification since jobstreamer-control-bus v0.10.0.
I enabled maven-job-streamer-plugin to be authenticated by username and password.
So I added username and password to pom.xml.